### PR TITLE
round-nan-check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,9 @@ checkstyle {
 jar {
     baseName = 'opendatakit-javarosa'
     // Be sure to update version in pom.xml to match
-    version = '2.2.0'
+    // snapshot release = x.x.x-SNAPSHOT
+    // production release = x.x.x
+    version = '2.3.0-SNAPSHOT'
     archiveName = baseName + '-' + version + '.jar'
 
     manifest {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,9 @@
   <groupId>org.opendatakit</groupId>
   <artifactId>opendatakit-javarosa</artifactId>
   <!-- Be sure to update version in build.gradle to match -->
-  <version>2.2.0</version> 
+  <!-- snapshot release = x.x.x-SNAPSHOT -->
+  <!-- production release = x.x.x -->
+  <version>2.3.0-SNAPSHOT</version> 
   <packaging>jar</packaging>
   <name>opendatakit-javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>

--- a/resources/formindex-serialization.xml
+++ b/resources/formindex-serialization.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+   <h:head>
+      <h:title>FormIndex Serialization</h:title>
+      <model>
+         <instance>
+            <data id="formindex-serialization">
+               <section_1>
+                  <question_1/>
+               </section_1>
+            </data>
+         </instance>
+         <bind nodeset="/data/section_1"/>
+         <bind nodeset="/data/section_1/question_1" type="string"/>
+      </model>
+   </h:head>
+   <h:body>
+      <group nodeset="/data/section_1">
+         <label>Section 1</label>
+         <input ref="/data/section_1/question_1">
+            <label>Question 1</label>
+         </input>
+      </group>
+   </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/FormIndex.java
+++ b/src/org/javarosa/core/model/FormIndex.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.core.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +40,7 @@ import org.javarosa.core.model.instance.TreeReference;
  * @author Clayton Sims
  *
  */
-public class FormIndex {
+public class FormIndex implements Serializable {
 
 	private boolean beginningOfForm = false;
 

--- a/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/org/javarosa/core/model/instance/TreeReference.java
@@ -19,6 +19,7 @@ package org.javarosa.core.model.instance;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +32,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.expr.XPathExpression;
 
-public class TreeReference implements Externalizable {
+public class TreeReference implements Externalizable, Serializable {
 	public static final int DEFAULT_MUTLIPLICITY = 0;//multiplicity
 	public static final int INDEX_UNBOUND = -1;//multiplicity
 	public static final int INDEX_TEMPLATE = -2;//multiplicity

--- a/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -6,6 +6,7 @@ package org.javarosa.core.model.instance;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 
 import org.javarosa.core.util.ArrayUtilities;
@@ -21,7 +22,7 @@ import org.javarosa.xpath.expr.XPathExpression;
  * @author ctsims
  *
  */
-public class TreeReferenceLevel implements Externalizable {
+public class TreeReferenceLevel implements Externalizable, Serializable {
 	public static final int MULT_UNINIT = -16;
 	
 	private String name;

--- a/src/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/org/javarosa/xpath/expr/XPathExpression.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.xpath.expr;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.util.externalizable.Externalizable;
 
-public abstract class XPathExpression implements Externalizable {
+public abstract class XPathExpression implements Externalizable, Serializable {
 
 	public Object eval (EvaluationContext evalContext) {
 		return this.eval(evalContext.getMainInstance(), evalContext);

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1036,7 +1036,7 @@ public class XPathFuncExpr extends XPathExpression {
      */
     private static Double round(double number, int numDecimals) {
         // rounding doesn't affect special values
-        if (number == NaN || number == NEGATIVE_INFINITY || number == POSITIVE_INFINITY) {
+        if (Double.isNaN(number) || Double.isInfinite(number)) {
             return number;
         }
 

--- a/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
+++ b/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
@@ -1,0 +1,94 @@
+package org.javarosa.core.model.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.file.Paths;
+
+import org.javarosa.core.PathConst;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FormIndexSerializationTest {	
+
+	@Test
+	public void testBeginningOfForm() throws IOException, ClassNotFoundException {
+		FormIndex formIndexToSerialize = FormIndex.createBeginningOfFormIndex();
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+
+	@Test
+	public void testEndOfForm() throws IOException, ClassNotFoundException {
+		FormIndex formIndexToSerialize = FormIndex.createEndOfFormIndex();
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+	
+	@Test
+	public void testLocalAndInstanceNullReference() throws IOException, ClassNotFoundException {
+		FormIndex formIndexToSerialize = new FormIndex(1, 2, null);
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+
+	@Test
+	public void testLocalAndInstanceNonNullReference() throws IOException, ClassNotFoundException {
+		TreeReference treeReference = TreeReference.rootRef();
+		FormIndex formIndexToSerialize = new FormIndex(1, 2, treeReference);
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+
+	@Test
+	public void testOnFormController() throws IOException, ClassNotFoundException {
+		FormParseInit formParseInit = new FormParseInit();
+		formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "formindex-serialization.xml").toString());
+		FormEntryController formEntryController = formParseInit.getFormEntryController();
+		
+		FormIndex formIndex = formEntryController.getModel().getFormIndex();
+		assertFormIndex(formIndex, deserializeFormIndex(serializeObject(formIndex)));
+		
+		do {
+			formIndex = formEntryController.getModel().incrementIndex(formIndex);
+			assertFormIndex(formIndex, deserializeFormIndex(serializeObject(formIndex)));		
+		} while (!formIndex.isEndOfFormIndex());
+	}
+
+	// helper methods -->
+
+	private static byte[] serializeObject(Serializable serializable)
+			throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(serializable);
+		oos.close();
+		return baos.toByteArray();
+	}
+
+	private static FormIndex deserializeFormIndex(byte[] serializedFormIndex) 
+			throws IOException, ClassNotFoundException {
+		ByteArrayInputStream bais = new ByteArrayInputStream(serializedFormIndex);
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Object o = ois.readObject();
+		return (FormIndex) o;
+	}
+
+	// Fails if expected FormIndex is not equal to actual FormIndex.
+	private static void assertFormIndex(FormIndex expected, FormIndex actual) {
+		assertEquals(expected, actual);
+		assertEquals(expected.getReference(), actual.getReference());
+	}
+}

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -331,6 +331,7 @@ public class XPathEvalTest extends TestCase {
         testEval("round('12345.12345', -2)", 12300.0);
         testEval("round('12350.12345', -2)", 12400.0);
         testEval("round('12345.12345', -3)", 12000.0);
+        testEval("round('1 div 0', 0)", NaN);
         // Todo: get round('12345.15', 1) and round('-12345.15', 1) working on Java 8
         // See discussion at https://github.com/opendatakit/javarosa/pull/42#issuecomment-299527754
 


### PR DESCRIPTION
Fixes old, broken NaN check in XPathEvalTest.round. See discussion in Issue 71.